### PR TITLE
AttributeDict could not pickle

### DIFF
--- a/attributedict/collections.py
+++ b/attributedict/collections.py
@@ -294,12 +294,6 @@ class AttributeDict(dict):
         """
         return self.__dict__.__contains__(key)
 
-    def __reduce__(self):
-        """
-        Return state information for pickling.
-        """
-        return self.__dict__.__reduce__()
-
     def __eq__(self, other):
         """
         Check dictionary is equal to another provided dictionary.

--- a/attributedict/tests/test_collections.py
+++ b/attributedict/tests/test_collections.py
@@ -14,6 +14,8 @@ from attributedict.tests import helper
 import attributedict
 import attributedict.collections as collections
 
+import pickle
+
 AttributeDict = collections.AttributeDict
 
 class CustomAttributeDict(AttributeDict):
@@ -37,6 +39,12 @@ class TestCase(helper.TestCase):
 
         self.assertTrue(hasattr(attributedict.collections, 'attrdict'))
         self.assertEqual(attributedict.collections.attrdict, attributedict.collections.attrdict)
+
+    def test_pickle(self):
+        attr_dict = AttributeDict({'foo': {'bar': 3}})
+        data = pickle.dumps(attr_dict)
+        restored_attr_dict = pickle.loads(data)
+        self.assertDeepEqual(attr_dict, restored_attr_dict)
 
     def test_init(self):
         for _AttributeDict in [AttributeDict, CustomAttributeDict]:


### PR DESCRIPTION
According to [python pickle](https://docs.python.org/2/library/pickle.html#what-can-be-pickled-and-unpickled), object containing pickable object (**Including AttributeDict**) should pickle.

But `AttributeDict` implements `__reduce__` which override the origin [pickle process](https://docs.python.org/2/library/pickle.html#pickling-and-unpickling-extension-types), and even call `__reduce__` on `__dict__` doesn't actually pickle a dict. Instead, it will throw `TypeError: can't pickle dict objects` even the `__dict__` itself is pickable.